### PR TITLE
Generally pass query arguments through filters

### DIFF
--- a/activity.php
+++ b/activity.php
@@ -77,13 +77,15 @@ function wp_dashboard_activity() {
  */
 function dash_show_published_posts( $args ) {
 
-	$posts = new WP_Query(array(
+	$query_args = array(
 		'post_type'      => 'post',
 		'post_status'    => $args['status'],
 		'orderby'        => 'date',
 		'order'          => $args['order'],
 		'posts_per_page' => intval( $args['max'] )
-	));
+	);
+	$query_args = apply_filters( 'dash_show_published_posts_query_args', $query_args );
+	$posts = new WP_Query( $query_args );
 
 	if ( $posts->have_posts() ) {
 

--- a/quickdraft.php
+++ b/quickdraft.php
@@ -109,14 +109,16 @@ function wp_dashboard_quick_draft() {
  */
 function wp_dashboard_recent_quickdrafts( $drafts = false ) {
 	if ( !$drafts ) {
-		$drafts_query = new WP_Query( array(
+		$query_args = array(
 			'post_type'      => 'post',
 			'post_status'    => 'draft',
 			'author'         => $GLOBALS['current_user']->ID,
 			'posts_per_page' => 4,
 			'orderby'        => 'modified',
 			'order'          => 'DESC'
-		) );
+		);
+		$query_args = apply_filters( 'dash_recent_quickdrafts_query_args', $query_args );
+		$drafts_query = new WP_Query( $query_args );
 		$drafts =& $drafts_query->posts;
 	}
 


### PR DESCRIPTION
To improve extensibility, pass any / all query arguments through filters. This allows the user to, for instance, change the Activity Widget from recent Posts to a CPT.

Previously: http://make.wordpress.org/ui/2013/10/11/dash-update-4/#comment-24013
