### PR TITLE
Fixed `margin-bottom` and Class Encapsulated Quickdraft

### DIFF
--- a/css/quickdraft.css
+++ b/css/quickdraft.css
@@ -14,8 +14,9 @@
 	padding: 8px 12px 0;
 }
 
-#dashboard_quick_draft .inside {
+#dashboard_quick_draft.postbox .inside {
 	padding: 0;
+	margin-bottom: 10px;
 }
 
 /* Form styling */
@@ -40,7 +41,7 @@ form.initial-form.quickpress-open input#title {
 	height: auto;
 }
 
-#dashboard_quick_draft input, 
+#dashboard_quick_draft input,
 #dashboard_quick_draft textarea {
 	box-sizing: border-box;
 	-moz-box-sizing:border-box;
@@ -173,7 +174,7 @@ form.initial-form.quickpress-open input#title {
 	height: auto;
 }
 
-#dashboard_quick_draft input, 
+#dashboard_quick_draft input,
 #dashboard_quick_draft textarea {
 	box-sizing: border-box;
 	-moz-box-sizing:border-box;

--- a/css/rightnow.css
+++ b/css/rightnow.css
@@ -6,7 +6,7 @@
 #dash-right-now li {
 	width: 50%;
 	float: left;
-	margin-bottom: 10px;
+	margin-bottom: 12px;
 }
 
 #dash-right-now .inside {

--- a/quickdraft.php
+++ b/quickdraft.php
@@ -1,171 +1,208 @@
 <?php
 
 /**
- * Add the QuickDraft widget to the dashboard
- *
- *
- *
- * @since 3.8.0
- *
- */
-function add_quickdraft_dashboard_widget() {
-	if ( is_blog_admin() && current_user_can( 'edit_posts' ) )
-		add_meta_box(
-		'dashboard_quick_draft',
-		__( 'Quick Draft' ),
-		'wp_dashboard_quick_draft',
-		'dashboard',
-		'side',
-		'high'
-	);
-}
-add_action( 'wp_dashboard_setup', 'add_quickdraft_dashboard_widget' );
-
-/**
- * Quick Draft $_POST is handled here
- *
  *
  *
  * @since 3.8.0
- *
  */
-function dashboard_plugin_quickdraft_admin_post() {
-	// Check nonce and capabilities
-	$nonce = $_REQUEST['_wpnonce'];
-	$error_msg = false;
-	if ( ! wp_verify_nonce( $nonce, 'add-post' ) )
-		$error_msg = 'Unable to submit this form, please refresh and try again.';
-		
-	if ( ! current_user_can( 'edit_posts' ) )
-		$error_msg = "Oops, you don't have access to add new drafts.";
-		
-	if ( $error_msg )
-		return wp_dashboard_quick_draft( $error_msg );
-		
-	$post = get_post( $_REQUEST['post_ID'] );
-	check_admin_referer( 'add-' . $post->post_type );
-	edit_post();
-	return wp_dashboard_quick_draft();
-}
-add_action( 'admin_post_new-quickdraft-post', 'dashboard_plugin_quickdraft_admin_post' );
-
-/**
- * The Quick Draft widget display and creation of drafts
- *
- *
- *
- * @since 3.8.0
- *
- */
-function wp_dashboard_quick_draft( $error_msg=false ) {
-	global $post_ID;
-
-	/* Check if a new auto-draft (= no new post_ID) is needed or if the old can be used */
-	$last_post_id = (int) get_user_option( 'dashboard_quick_press_last_post_id' ); // Get the last post_ID
-	if ( $last_post_id ) {
-		$post = get_post( $last_post_id );
-		if ( empty( $post ) || $post->post_status != 'auto-draft' ) { // auto-draft doesn't exists anymore
-			$post = get_default_post_to_edit( 'post', true );
-			update_user_option( get_current_user_id(), 'dashboard_quick_press_last_post_id', (int) $post->ID ); // Save post_ID
-		} else {
-			$post->post_title = ''; // Remove the auto draft title
-		}
-	} else {
-		$post = get_default_post_to_edit( 'post' , true);
-		$user_id = get_current_user_id();
-		// Don't create an option if this is a super admin who does not belong to this site.
-		if ( ! ( is_super_admin( $user_id ) && ! in_array( get_current_blog_id(), array_keys( get_blogs_of_user( $user_id ) ) ) ) )
-			update_user_option( $user_id, 'dashboard_quick_press_last_post_id', (int) $post->ID ); // Save post_ID
+class WP_Dash_Widget_Quickdraft {
+	public function __construct(){
+		add_action( 'wp_dashboard_setup', array(&$this, 'setup') );
+		add_action( 'admin_post_new-quickdraft-post', array(&$this, 'save') );
 	}
 
-	$post_ID = (int) $post->ID;
-	
-	do_action( 'dashboard_quickdraft_beginning', $post );
-?>
+	/**
+	 * Setup the Quickdraft as a Dashboard Widget
+	 *
+	 * @uses add_meta_box
+	 * @uses is_blog_admin
+	 * @uses current_user_can
+	 * @since 3.8.0
+	 *
+	 * @return (bool) If was possible to add the widget
+	 */
+	public function setup(){
+		if (!is_blog_admin() || !current_user_can( 'edit_posts' ))
+			return false;
 
-	<form name="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post" id="quick-press" class="initial-form">
-		
-		<?php if ($error_msg) : ?>
-		<div class="error"><?php _e( $error_msg ); ?></div>
-		<?php endif; ?>
-		
-		<div class="input-text-wrap" id="title-wrap">
-			<label class="screen-reader-text prompt" for="title" id="title-prompt-text"><?php _e( "What's on your mind?" ); ?></label>
-			<input type="text" name="post_title" id="title" autocomplete="off" />
-		</div>
+		add_meta_box(
+			'dashboard_quick_draft',
+			__( 'Quick Draft' ),
+			array(&$this, 'html'),
+			'dashboard',
+			'side',
+			'high'
+		);
+		return true;
+	}
 
-		<div class="textarea-wrap" id="description-wrap">
-			<label class="screen-reader-text prompt" for="content" id="content-prompt-text"><?php _e( 'Enter a description' ); ?></label>
-			<textarea name="content" id="content" class="mceEditor" rows="3" cols="15"></textarea>
-		</div>
+	/**
+	 * Creates the HTML for the Widget
+	 *
+	 * @uses get_user_option
+	 * @uses get_post
+	 * @uses get_default_post_to_edit
+	 * @uses update_user_option
+	 * @uses get_current_user_id
+	 * @uses is_super_admin
+	 * @uses get_blogs_of_user
+	 * @uses do_action
+	 * @uses wp_nonce_field
+	 * @uses submit_button
+	 * @since 3.8.0
+	 *
+	 * @return (string) HTML of the Widget
+	 */
+	public function html( $error_msg=false ){
+		global $post_ID;
 
-		<p class="submit">
-			<input type="hidden" name="action" id="quickpost-action" value="new-quickdraft-post" />
-			<input type="hidden" name="post_ID" value="<?php echo $post_ID; ?>" />
-			<input type="hidden" name="post_type" value="post" />
-			<?php wp_nonce_field( 'add-post' ); ?>
-			<?php submit_button( __( 'Save Draft' ), 'primary', 'save', false, array( 'id' => 'save-post' ) ); ?>
-			<br class="clear" />
-		</p>
-
-	</form>
-
-<?php
-	wp_dashboard_recent_quickdrafts();
-	
-	do_action( 'dashboard_quickdraft_end' );
-}
-
-/**
- * Show `Recent Drafts` below Quick Draft form
- *
- *
- *
- * @since 3.8.0
- *
- */
-function wp_dashboard_recent_quickdrafts() {
-
-	$query_args = array(
-		'post_type'      => 'post',
-		'post_status'    => 'draft',
-		'author'         => $GLOBALS['current_user']->ID,
-		'posts_per_page' => 4,
-		'orderby'        => 'modified',
-		'order'          => 'DESC'
-	);
-	$query_args = apply_filters( 'dash_recent_quickdrafts_query_args', $query_args );
-	$drafts_query = new WP_Query( $query_args );
-	$drafts =& $drafts_query->posts;
-
-
-	if ( $drafts && is_array( $drafts ) ) {
-		$list = array();
-		$draft_count = 0;
-		foreach ( $drafts as $draft ) {
-			if ( 3 == $draft_count )
-				break;
-			
-			$draft_count++;
-			
-			$url = get_edit_post_link( $draft->ID );
-			$title = _draft_or_post_title( $draft->ID );
-			$item = '<a href="' . $url . '" title="' . sprintf( __( 'Edit &#8220;%s&#8221;' ), esc_attr( $title ) ) . '">' . esc_html( $title ) . '</a> <time datetime="' . get_the_time( 'c', $draft) . '">' . get_the_time( get_option( 'date_format' ), $draft ) . '</time>';
-			if ( $the_content = wp_trim_words( $draft->post_content, 10 ) )
-				$item .= '<p>' . $the_content . '</p>';
-			$list[] = $item;
+		/* Check if a new auto-draft (= no new post_ID) is needed or if the old can be used */
+		$last_post_id = (int) get_user_option( 'dashboard_quick_press_last_post_id' ); // Get the last post_ID
+		if ( $last_post_id ) {
+			$post = get_post( $last_post_id );
+			if ( empty( $post ) || $post->post_status != 'auto-draft' ) { // auto-draft doesn't exists anymore
+				$post = get_default_post_to_edit( 'post', true );
+				update_user_option( get_current_user_id(), 'dashboard_quick_press_last_post_id', (int) $post->ID ); // Save post_ID
+			} else {
+				$post->post_title = ''; // Remove the auto draft title
+			}
+		} else {
+			$post = get_default_post_to_edit( 'post' , true);
+			$user_id = get_current_user_id();
+			// Don't create an option if this is a super admin who does not belong to this site.
+			if ( ! ( is_super_admin( $user_id ) && ! in_array( get_current_blog_id(), array_keys( get_blogs_of_user( $user_id ) ) ) ) )
+				update_user_option( $user_id, 'dashboard_quick_press_last_post_id', (int) $post->ID ); // Save post_ID
 		}
-		
-		do_action( 'dashboard_quickdraft_drafts_list', $drafts );
-?>
-	<div class="drafts">
-		<?php if ( 3 < count($drafts) ) { ?>
-		<p class="view-all"><a href="edit.php?post_status=draft" ><?php _e( 'View all' ); ?></a></p>
-		<?php } ?>
-		<h4><?php _e('Drafts'); ?></h4>
-		<ul id="draft-list">
-			<li><?php echo join( "</li>\n<li>", $list ); ?></li>
-		</ul>
-	</div>
-<?php }
+
+		$post_ID = (int) $post->ID;
+
+		do_action( 'dashboard_quickdraft_beginning', $post );
+	?>
+
+		<form name="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" method="post" id="quick-press" class="initial-form">
+
+			<?php if ($error_msg) : ?>
+			<div class="error"><?php _e( $error_msg ); ?></div>
+			<?php endif; ?>
+
+			<div class="input-text-wrap" id="title-wrap">
+				<label class="screen-reader-text prompt" for="title" id="title-prompt-text"><?php _e( "What's on your mind?" ); ?></label>
+				<input type="text" name="post_title" id="title" autocomplete="off" />
+			</div>
+
+			<div class="textarea-wrap" id="description-wrap">
+				<label class="screen-reader-text prompt" for="content" id="content-prompt-text"><?php _e( 'Enter a description' ); ?></label>
+				<textarea name="content" id="content" class="mceEditor" rows="3" cols="15"></textarea>
+			</div>
+
+			<p class="submit">
+				<input type="hidden" name="action" id="quickpost-action" value="new-quickdraft-post" />
+				<input type="hidden" name="post_ID" value="<?php echo $post_ID; ?>" />
+				<input type="hidden" name="post_type" value="post" />
+				<?php wp_nonce_field( 'add-post' ); ?>
+				<?php submit_button( __( 'Save Draft' ), 'primary', 'save', false, array( 'id' => 'save-post' ) ); ?>
+				<br class="clear" />
+			</p>
+
+		</form>
+
+	<?php
+		$this->recent();
+
+		do_action( 'dashboard_quickdraft_end' );
+	}
+
+	/**
+	 * Creates the HTML for the Recent QuickDrafts
+	 *
+	 * @uses apply_filters
+	 * @uses class WP_Query
+	 * @uses get_edit_post_link
+	 * @uses _draft_or_post_title
+	 * @uses esc_attr
+	 * @uses esc_html
+	 * @uses get_the_time
+	 * @uses get_option
+	 * @uses wp_trim_words
+	 * @uses do_action
+	 * @since 3.8.0
+	 *
+	 * @return (string) HTML of the 4 lastest quickdrafts
+	 */
+	private function recent(){
+		$query_args = array(
+			'post_type'      => 'post',
+			'post_status'    => 'draft',
+			'author'         => $GLOBALS['current_user']->ID,
+			'posts_per_page' => 4,
+			'orderby'        => 'modified',
+			'order'          => 'DESC'
+		);
+		$query_args = apply_filters( 'dash_recent_quickdrafts_query_args', $query_args );
+		$drafts_query = new WP_Query( $query_args );
+		$drafts =& $drafts_query->posts;
+
+
+		if ( $drafts && is_array( $drafts ) ) {
+			$list = array();
+			$draft_count = 0;
+			foreach ( $drafts as $draft ) {
+				if ( 3 == $draft_count )
+					break;
+
+				$draft_count++;
+
+				$url = get_edit_post_link( $draft->ID );
+				$title = _draft_or_post_title( $draft->ID );
+				$item = '<a href="' . $url . '" title="' . sprintf( __( 'Edit &#8220;%s&#8221;' ), esc_attr( $title ) ) . '">' . esc_html( $title ) . '</a> <time datetime="' . get_the_time( 'c', $draft) . '">' . get_the_time( get_option( 'date_format' ), $draft ) . '</time>';
+				if ( $the_content = wp_trim_words( $draft->post_content, 10 ) )
+					$item .= '<p>' . $the_content . '</p>';
+				$list[] = $item;
+			}
+
+			do_action( 'dashboard_quickdraft_drafts_list', $drafts );
+	?>
+		<div class="drafts">
+			<?php if ( 3 < count($drafts) ) { ?>
+			<p class="view-all"><a href="edit.php?post_status=draft" ><?php _e( 'View all' ); ?></a></p>
+			<?php } ?>
+			<h4><?php _e('Drafts'); ?></h4>
+			<ul id="draft-list">
+				<li><?php echo join( "</li>\n<li>", $list ); ?></li>
+			</ul>
+		</div>
+	<?php }
+	}
+
+	/**
+	 * Hook to the `admin_post` AJAX and return the quickdraft widget HTML
+	 *
+	 * @uses get_post
+	 * @uses wp_verify_nonce
+	 * @uses current_user_can
+	 * @uses check_admin_referer
+	 * @uses edit_post
+	 * @since 3.8.0
+	 *
+	 * @return (string) Returns the HTML of the widget
+	 */
+	public function save(){
+		// Check nonce and capabilities
+		$nonce = $_REQUEST['_wpnonce'];
+		$error_msg = false;
+		if ( ! wp_verify_nonce( $nonce, 'add-post' ) )
+			$error_msg = 'Unable to submit this form, please refresh and try again.';
+
+		if ( ! current_user_can( 'edit_posts' ) )
+			$error_msg = "Oops, you don't have access to add new drafts.";
+
+		if ( $error_msg )
+			return $this->html( $error_msg );
+
+		$post = get_post( $_REQUEST['post_ID'] );
+		check_admin_referer( 'add-' . $post->post_type );
+		edit_post();
+		return $this->html();
+	}
 }
+new WP_Dash_Widget_Quickdraft;


### PR DESCRIPTION
Based on what @growthdesigner said I fixed the CSS file; I got the 2.1.1 version of MP6 and still got the error (Mac OS X, Chrome).

Even if MP6 address this problem I think we should have a fix on wp-dash.

No `!important`by the way.

Then I've did what @danielbachhuber commented on the #7, encapsulating a Widget in to Class; But I'm not sure if choosen a good name since there are some `dash_` and some `dashboard_`
